### PR TITLE
Explain rpc.run()

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ rpc.set_activity(
 
 rpc.run()
 ```
+Note that `rpc.run()` is only required to keep your program alive. If another task is doing so then it isn't required.
 
 More examples [here](https://github.com/LyQuid12/discord-rpc/tree/main/examples)
 


### PR DESCRIPTION
`rpc.run()` is only required to keep the application alive, which isn't explained in `README.md`. If another module or task or whatnot is keeping the script running, running `rpc.run()` will just cause the other script to stop functioning, if not threaded.